### PR TITLE
[Feat]add custome image training for ms1.9 ascend

### DIFF
--- a/domain/dp_training.go
+++ b/domain/dp_training.go
@@ -29,6 +29,10 @@ var (
 		"Completed":  true,
 		"Terminated": true,
 	}
+
+	customizeVersionSet = map[string]string{
+		"mindspore_1.9.0-cann_6.0.RC1-py_3.7-ubuntu_18.04-amd64": "xihe-image/mindspore-ascend-ubuntu-aarch64:1.9.0-cann6.0.RC1",
+	}
 )
 
 // Account
@@ -103,6 +107,7 @@ func (r trainingDesc) TrainingDesc() string {
 // Directory
 type Directory interface {
 	Directory() string
+	LastDirectory() string
 }
 
 func NewDirectory(v string) (Directory, error) {
@@ -121,6 +126,12 @@ type directory string
 
 func (r directory) Directory() string {
 	return string(r)
+}
+
+func (r directory) LastDirectory() string {
+	s := strings.TrimRight(string(r), "/")
+	splitDir := strings.Split(s, "/")
+	return splitDir[len(splitDir)-1]
 }
 
 // FilePath
@@ -168,6 +179,7 @@ func (r computeType) ComputeType() string {
 // ComputeVersion
 type ComputeVersion interface {
 	ComputeVersion() string
+	ComputeImage() string
 }
 
 func NewComputeVersion(v string) (ComputeVersion, error) {
@@ -182,6 +194,14 @@ type computeVersion string
 
 func (r computeVersion) ComputeVersion() string {
 	return string(r)
+}
+
+// 判断是否是自定义镜像, 并返回IMAGE_URL
+func (r computeVersion) ComputeImage() string {
+	if v, ok := customizeVersionSet[string(r)]; ok {
+		return v
+	}
+	return ""
 }
 
 // ComputeFlavor

--- a/huaweicloud/modelarts/request.go
+++ b/huaweicloud/modelarts/request.go
@@ -21,6 +21,7 @@ type MetadataOption struct {
 type AlgorithmOption struct {
 	CodeDir      string              `json:"code_dir"`
 	BootFile     string              `json:"boot_file"`
+	Command      string              `json:"command"`
 	Engine       EngineOption        `json:"engine"`
 	Parameters   []ParameterOption   `json:"parameters"`
 	Environments map[string]string   `json:"environments"`
@@ -31,6 +32,7 @@ type AlgorithmOption struct {
 type EngineOption struct {
 	EngineName    string `json:"engine_name"`
 	EngineVersion string `json:"engine_version"`
+	ImageURL      string `json:"image_url"`
 }
 
 type ParameterOption struct {

--- a/huaweicloud/trainingimpl/training.go
+++ b/huaweicloud/trainingimpl/training.go
@@ -153,6 +153,11 @@ func (impl trainingImpl) Create(t *domain.UserTraining) (info domain.JobInfo, er
 		})
 	}
 
+	bootFile := filepath.Join(obs, t.CodeDir.Directory(), t.BootFile.FilePath())
+	if t.IsCustomizeImageTraining() {
+		bootFile = ""
+	}
+
 	opt := modelarts.JobCreateOption{
 		Kind: "job",
 		Metadata: modelarts.MetadataOption{
@@ -161,10 +166,12 @@ func (impl trainingImpl) Create(t *domain.UserTraining) (info domain.JobInfo, er
 		},
 		Algorithm: modelarts.AlgorithmOption{
 			CodeDir:  filepath.Join(obs, t.CodeDir.Directory()) + obsDelimiter,
-			BootFile: filepath.Join(obs, t.CodeDir.Directory(), t.BootFile.FilePath()),
+			BootFile: bootFile,
+			Command:  t.DefaultCommand(),
 			Engine: modelarts.EngineOption{
 				EngineName:    t.Compute.Type.ComputeType(),
 				EngineVersion: t.Compute.Version.ComputeVersion(),
+				ImageURL:      t.Compute.Version.ComputeImage(),
 			},
 			Outputs: outputs,
 		},


### PR DESCRIPTION
为什么？
- 目前训练功能CPU、GPU可以通过覆盖版本来更新mindspore版本，但是由于mindspore-ascend版本与训练镜像的CANN版本强关联，需要使用自定义镜像的方式
- 需要增加对不同Ascend版本的支持

什么场景？
- 华为云场景下的训练方式

做了什么？
- 增加了自定义镜像的训练方式，目前只适配mindspore 1.9 ascend版本（主要更改了modelarts创建训练的请求体，增加了command、imageurl字段，同时需要适配的修改了boot_file）
